### PR TITLE
Add Pry::Helpers::Text.colorize(color, text, bold?)

### DIFF
--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -38,6 +38,18 @@ class Pry
           end
         end
       end
+      
+      # Apply `color` and optional boldness to `text`
+      #
+      # @param color [Symbol] Color selected from `COLORS`
+      # @param text [String]
+      # @param bold [nil, true, false]
+      # @return [String] Text
+      def colorize(color, text, bold = false)
+        text
+          .then{ |it| bold ? bold(it) : it }
+          .then{ |it| send(color, it) }
+      end
 
       # Remove any color codes from _text_.
       #


### PR DESCRIPTION
Good people of pry-core, hello!

I was in the process of developing some fun console coloring options as part of Pry/StackExplorer and Pry/Rails, and wanting to allow users to customize their colors, I noticed the following: 

If the color instructions (coloring, boldness) are offered as data, it is a bit unwieldy to turn that into colored text. For instance, if the config says `{color: :red, bold: true}`, it's non-obvious to turn that into the right helper invocation.

There's also the caveat that bold needs to be applied before color. (or is it the reverse?) I can never remember.

*(FYI, I also have another patch in store that allows for faded text. Stay tuned)*

Now this patch is a bit quick and dirty, so have at it. Is there some bandwidth and appetite at maintenance to merge this if the tests and the code are good? Let me know and I would get on that.